### PR TITLE
Extend player movements in all directions, and fix jitters in the student's movement animations.

### DIFF
--- a/assets/student.json
+++ b/assets/student.json
@@ -1,14 +1,5 @@
 {"frames": [
 
-{
-		"filename": "stop",
-		"frame": {"x":0,"y":128,"w":64,"h":64},
-		"rotated": false,
-		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
-		"sourceSize": {"w":64,"h":64}
-	},
-
 	{
 		"filename": "left1",
 		"frame": {"x":0,"y":64,"w":64,"h":64},
@@ -35,7 +26,7 @@
 	},
 	{
 		"filename": "left4",
-		"frame": {"x":196,"y":64,"w":64,"h":64},
+		"frame": {"x":192,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -43,7 +34,7 @@
 	},
 	{
 		"filename": "left5",
-		"frame": {"x":254,"y":64,"w":64,"h":64},
+		"frame": {"x":256,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -51,7 +42,7 @@
 	},
 	{
 		"filename": "left6",
-		"frame": {"x":318,"y":64,"w":64,"h":64},
+		"frame": {"x":320,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -59,7 +50,7 @@
 	},
 	{
 		"filename": "left7",
-		"frame": {"x":382,"y":64,"w":64,"h":64},
+		"frame": {"x":384,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -67,7 +58,7 @@
 	},
 	{
 		"filename": "left8",
-		"frame": {"x":446,"y":64,"w":64,"h":64},
+		"frame": {"x":448,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -75,7 +66,7 @@
 	},
 	{
 		"filename": "left9",
-		"frame": {"x":510,"y":64,"w":64,"h":64},
+		"frame": {"x":512,"y":64,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -109,7 +100,7 @@
 	},
 	{
 		"filename": "right4",
-		"frame": {"x":196,"y":196,"w":64,"h":64},
+		"frame": {"x":192,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -118,7 +109,7 @@
 
 	{
 		"filename": "right5",
-		"frame": {"x":254,"y":196,"w":64,"h":64},
+		"frame": {"x":256,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -126,7 +117,7 @@
 	},
 	{
 		"filename": "right6",
-		"frame": {"x":318,"y":196,"w":64,"h":64},
+		"frame": {"x":320,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -135,7 +126,7 @@
 
 	{
 		"filename": "right7",
-		"frame": {"x":382,"y":196,"w":64,"h":64},
+		"frame": {"x":384,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -143,7 +134,7 @@
 	},
 	{
 		"filename": "right8",
-		"frame": {"x":446,"y":196,"w":64,"h":64},
+		"frame": {"x":448,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -152,7 +143,7 @@
 
 	{
 		"filename": "right9",
-		"frame": {"x":510,"y":196,"w":64,"h":64},
+		"frame": {"x":512,"y":196,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
@@ -160,33 +151,72 @@
 	},
 
 	{
-		"filename": "up1",
-		"frame": {"x":128,"y":196,"w":64,"h":64},
+		"filename": "front1",
+		"frame": {"x":0,"y":128,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
 		"sourceSize": {"w":64,"h":64}
 	},
 	{
-		"filename": "up2",
-		"frame": {"x":254,"y":196,"w":64,"h":64},
-		"rotated": false,
-		"trimmed": true,
-		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
-		"sourceSize": {"w":64,"h":64}
-	},
-
-	{
-		"filename": "down1",
-		"frame": {"x":196,"y":196,"w":64,"h":64},
+		"filename": "front2",
+		"frame": {"x":64,"y":128,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
 		"sourceSize": {"w":64,"h":64}
 	},
 	{
-		"filename": "down2",
-		"frame": {"x":64,"y":196,"w":64,"h":64},
+		"filename": "front3",
+		"frame": {"x":128,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front4",
+		"frame": {"x":192,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front5",
+		"frame": {"x":256,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front6",
+		"frame": {"x":320,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front7",
+		"frame": {"x":384,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front8",
+		"frame": {"x":448,"y":128,"w":64,"h":64},
+		"rotated": false,
+		"trimmed": true,
+		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},
+		"sourceSize": {"w":64,"h":64}
+	},
+	{
+		"filename": "front9",
+		"frame": {"x":512,"y":128,"w":64,"h":64},
 		"rotated": false,
 		"trimmed": true,
 		"spriteSourceSize": {"x":0,"y":0,"w":576,"h":256},

--- a/script.js
+++ b/script.js
@@ -27,16 +27,12 @@ var game = new Phaser.Game(640,480, Phaser.AUTO, 'world', {
 Smc.playerTypes.Player = function (name, phaserObject) {
     this._defense = 1;
     this._name = name;
-    this._isGoingUp = false;
+    this._isMovingVertically = false;
     this._phaserObject = phaserObject;
     game.physics.arcade.enable(this._phaserObject);
-    this._phaserObject.animations.add('left', ['left1', 'left2','left3', 'left4','left5', 'left6','left7', 'left8','left9']);
+    this._phaserObject.animations.add('front', ['front1', 'front2', 'front3', 'front4', 'front5', 'front6', 'front7', 'front8', 'front9']);
+    this._phaserObject.animations.add('left', ['left1', 'left2', 'left3', 'left4', 'left5', 'left6', 'left7', 'left8', 'left9']);
     this._phaserObject.animations.add('right', ['right1', 'right2','right3', 'right4','right5', 'right6','right7', 'right8', 'right9']);
-    this._phaserObject.animations.add('up', ['up1', 'up2','up3', 'up4','up5', 'up6','up7', 'up8','up9']);
-    this._phaserObject.animations.add('down', ['down1', 'down2']);
-    this._phaserObject.animations.add('stop');
-    this._phaserObject.animations.play('stop', 5, true);
-    this._phaserObject.animations.play('stop', 5, true);
     this._phaserObject.body.gravity.set(0, 180);
     this._phaserObject.body.collideWorldBounds = true;
     this._phaserObject.anchor.setTo(0.5, 0.5);
@@ -95,12 +91,12 @@ Smc.playerTypes.Player.prototype._kill = function() {
  * Moves the player to the left.
  */
 Smc.playerTypes.Player.prototype.moveLeft = function() {
-    if (this._isGoingUp) {
+    if (this._isMovingVertically) {
         this._phaserObject.x = this._phaserObject.x - 10;
     } else {
         this._phaserObject.x = this._phaserObject.x - 5;
     }
-    this._phaserObject.animations.play('left', 15, false);
+    this._phaserObject.animations.play('left', 2, true);
     this._weaponMountPhaserObject.angle = 180;
     this._onMove();
 }
@@ -109,12 +105,12 @@ Smc.playerTypes.Player.prototype.moveLeft = function() {
  * Moves the player to the right.
  */
 Smc.playerTypes.Player.prototype.moveRight = function() {
-    if (this._isGoingUp) {
+    if (this._isMovingVertically) {
         this._phaserObject.x = this._phaserObject.x + 10;
     } else {
         this._phaserObject.x = this._phaserObject.x + 5;
     }
-    this._phaserObject.animations.play('right', 15, false);
+    this._phaserObject.animations.play('right', 2, true);
     this._weaponMountPhaserObject.x = x;
     this._weaponMountPhaserObject.angle = 0;
     this._onMove();
@@ -124,18 +120,24 @@ Smc.playerTypes.Player.prototype.moveRight = function() {
  * Moves the player upwards.
  */
 Smc.playerTypes.Player.prototype.moveUp = function() {
-    this._isGoingUp = true;
+    this._isMovingVertically = true;
     this._phaserObject.y = this._phaserObject.y - 10;
-    this._phaserObject.animations.play('up', 30, false);
+    this._phaserObject.animations.play('front', 2, true);
+    this._weaponMountPhaserObject.angle = 270;
     this._onMove();
-    this._isGoingUp = false;
+    this._isMovingVertically = false;
 }
 
 /**
  * Moves the player downwards.
  */
 Smc.playerTypes.Player.prototype.moveDown = function() {
+    this._isMovingVertically = true;
+    this._phaserObject.y = this._phaserObject.y + 10;
+    this._phaserObject.animations.play('front', 2, true);
+    this._weaponMountPhaserObject.angle = 90;
     this._onMove();
+    this._isMovingVertically = false;
 }
 
 /**
@@ -144,13 +146,6 @@ Smc.playerTypes.Player.prototype.moveDown = function() {
 Smc.playerTypes.Player.prototype._onMove = function() {
     this._weaponMountPhaserObject.y =   this._phaserObject.y;
     this._weaponMountPhaserObject.x =   this._phaserObject.x;
-}
-
-/**
- * Stops the player's movements.
- */
-Smc.playerTypes.Player.prototype.stopMoving = function() {
-    this._phaserObject.animations.play('stop', 1, false);
 }
 
 /**
@@ -285,7 +280,7 @@ Smc.phaserEventHandlers.create.push(function() {
     pump = game.add.sprite( pumpX, pumpY, 'pump');
     arm = game.add.sprite( armX, armY, 'arm');
     weight = game.add.sprite( weightX, weightY, 'weight');
-;
+
     game.physics.arcade.enable(box);
     game.physics.arcade.enable(lift);
     lift.body.collideWorldBounds = true;
@@ -307,17 +302,14 @@ Smc.phaserEventHandlers.update.push(function() {
     if (cursors.up.isDown) {
         student.moveUp();
     }
-    else {
-        student.stopMoving();
+    if (cursors.down.isDown) {
+        student.moveDown();
     }
-
     if (cursors.left.isDown) {
         student.moveLeft();
     }
-    else if (cursors.right.isDown) {
+    if (cursors.right.isDown) {
         student.moveRight();
-    } else {
-        student.stopMoving();
     }
 
     if (game.input.keyboard.isDown(Phaser.Keyboard.SPACEBAR)) {


### PR DESCRIPTION
- Add support for moving downwards. This introduces downwards shooting as well.
- Remove the separate animations for up and down, and use a single front-facing animation for those movements. This has the added benefit of indicating that if the student faces the player, they are shooting up or down (we have no sprites to distinguish between up and down, unless we use the sprites in which we see the student from behind).
- Remove the animations that were used when the student stopped moving, as they caused jitters. Instead, loop the previous animation slowly, so direction is indicated, but the animation speed is not annoyingly fast.
- Fixed the sprite cutout coordinates for the animations for moving left and right.
